### PR TITLE
fix: moveToEl returns null on missing selector (#2)

### DIFF
--- a/docs/helpers.md
+++ b/docs/helpers.md
@@ -26,15 +26,20 @@ await moveTo(page, 400, 300);
 
 ### `moveToEl(page, selector)`
 
-Animate the HUD cursor to the center of the element matching `selector`. Returns `{ x, y }` coordinates (always, even when HUD inactive — useful for subsequent clicks).
+Animate the HUD cursor to the center of the element matching `selector`. Returns `{ x, y }` for a matched element, or `null` if the selector doesn't match (no throw). When HUD is inactive, resolves coordinates but skips the animation.
 
 ```ts
-const center = await moveToEl(page, "#submit-btn");
+const pos = await moveToEl(page, "#submit-btn");
+if (pos) {
+  // safe to use pos.x / pos.y
+} else {
+  // selector did not match — handle gracefully
+}
 ```
 
 ### `clickEl(page, selector)`
 
-Animated click: moves cursor to element → shows ripple → performs DOM `.click()`. When HUD is inactive, just performs the DOM click without animation/delays.
+Animated click: moves cursor to element → shows ripple → performs DOM `.click()`. When HUD is inactive, just performs the DOM click without animation/delays. When the selector doesn't match any element, `clickEl` is a safe no-op (no throw).
 
 ```ts
 await clickEl(page, "#submit-btn");
@@ -57,8 +62,8 @@ await typeKeys(page, "hello@example.com", 55, "#email");
 |--------|-----------|-------------|
 | hudWait | Waits ms | Instant (no-op) |
 | moveTo | Animates cursor | No-op |
-| moveToEl | Animates cursor, returns coords | Returns coords only |
-| clickEl | Animate → ripple → click → wait | DOM click only |
+| moveToEl | Animates cursor, returns coords (or `null` if missing) | Returns coords only (or `null` if missing) |
+| clickEl | Animate → ripple → click → wait (no-op if missing) | DOM click only (no-op if missing) |
 | typeKeys | Char-by-char with key badges | Sets value directly |
 
 ## Tips

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -53,14 +53,22 @@ export async function moveTo(page: Page, x: number, y: number, steps = 10): Prom
 
 /**
  * Smoothly move the HUD cursor to the center of `selector`.
- * Returns the element center coordinates.
+ * Returns the element center coordinates, or `null` if the selector
+ * doesn't match any element.
  * When HUD is inactive, resolves coordinates but skips the animation.
  */
-export async function moveToEl(page: Page, selector: string): Promise<{ x: number; y: number }> {
+export async function moveToEl(
+  page: Page,
+  selector: string,
+): Promise<{ x: number; y: number } | null> {
   const center = await page.evaluate((s: string) => {
-    const r = document.querySelector(s)!.getBoundingClientRect();
+    const el = document.querySelector(s);
+    if (!el) return null;
+    const r = el.getBoundingClientRect();
     return { x: r.x + r.width / 2, y: r.y + r.height / 2 };
   }, selector);
+
+  if (!center) return null;
 
   if (await isHudActive(page)) {
     await moveTo(page, center.x, center.y);
@@ -82,6 +90,7 @@ export async function clickEl(page: Page, selector: string): Promise<void> {
   const active = await isHudActive(page);
   if (active) {
     const c = await moveToEl(page, selector);
+    if (!c) return;
     await page.waitForTimeout(150);
     await page.evaluate(
       ([x, y]: [number, number]) => {

--- a/tests/demo.spec.ts
+++ b/tests/demo.spec.ts
@@ -1,5 +1,6 @@
 import http from "node:http";
 import { test, expect } from "../src/index.js";
+import { moveToEl, clickEl } from "../src/helpers.js";
 
 const HTML = `<!DOCTYPE html>
 <html><head><style>
@@ -116,6 +117,16 @@ test("modifier keys show persistent badges", async ({ page }) => {
   expect(await page.evaluate(() => !document.querySelector("[data-qa-hud] .qa-key.modifier"))).toBe(
     true,
   );
+});
+
+test("moveToEl returns null on missing selector and clickEl is a no-op", async ({ page }) => {
+  await page.goto(baseUrl);
+
+  const pos = await moveToEl(page, "#does-not-exist");
+  expect(pos).toBeNull();
+
+  // Should not throw even though the element is missing.
+  await expect(clickEl(page, "#does-not-exist")).resolves.toBeUndefined();
 });
 
 test("HUD does not block page interactions", async ({ page }) => {

--- a/tests/demo.spec.ts
+++ b/tests/demo.spec.ts
@@ -122,6 +122,10 @@ test("modifier keys show persistent badges", async ({ page }) => {
 test("moveToEl returns null on missing selector and clickEl is a no-op", async ({ page }) => {
   await page.goto(baseUrl);
 
+  // Lock in HUD-active coverage so a regression in setup can't silently
+  // turn this into a fast-path no-op test.
+  expect(await page.evaluate(() => !!(window as any).__qaHud)).toBe(true);
+
   const pos = await moveToEl(page, "#does-not-exist");
   expect(pos).toBeNull();
 


### PR DESCRIPTION
Closes #2

## Summary
- `moveToEl` now returns `null` when the selector doesn't match, instead of throwing `Cannot read properties of null (reading 'getBoundingClientRect')`.
- `clickEl` handles the null case by skipping the animation phase.

## Test plan
- [x] `npm run build` passes