### PR TITLE
fix: prevent narrate/caption from hanging on heavy SSR pages (#3)

### DIFF
--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -14,24 +14,24 @@ import { isHudActive, getTtsProvider, storeAudioSegment } from "./hud-registry.j
 // ---------------------------------------------------------------------------
 
 /**
- * Run `page.evaluate(...)` but reject after `timeoutMs` if the page event
- * loop is blocked (heavy SSR hydration, busy service worker, etc.).
+ * Run `page.evaluate(fn, arg)` but bail out after `timeoutMs` if the page
+ * event loop is blocked (heavy SSR hydration, busy service worker, etc.).
  *
  * On timeout, logs a warning and resolves with `undefined` so recordings
- * keep going instead of hitting the full Playwright test timeout.
+ * keep going instead of hitting the full Playwright test timeout. The
+ * underlying `page.evaluate` promise is left to settle on its own.
  */
-async function evaluateWithTimeout<R>(
+async function evaluateWithTimeout<A, R>(
   page: Page,
-  fn: Parameters<Page["evaluate"]>[0],
-  arg?: unknown,
+  fn: (arg: A) => R | Promise<R>,
+  arg: A,
   timeoutMs = 10_000,
   label = "page.evaluate",
 ): Promise<R | undefined> {
   let timer: NodeJS.Timeout | undefined;
   try {
-    return (await Promise.race([
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      (page.evaluate as any)(fn, arg),
+    return await Promise.race<R | undefined>([
+      page.evaluate<R, A>(fn, arg),
       new Promise<undefined>((resolve) => {
         timer = setTimeout(() => {
           // eslint-disable-next-line no-console
@@ -41,7 +41,7 @@ async function evaluateWithTimeout<R>(
           resolve(undefined);
         }, timeoutMs);
       }),
-    ])) as R | undefined;
+    ]);
   } finally {
     if (timer) clearTimeout(timer);
   }

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -10,6 +10,44 @@ import type { Page } from "@playwright/test";
 import { isHudActive, getTtsProvider, storeAudioSegment } from "./hud-registry.js";
 
 // ---------------------------------------------------------------------------
+// evaluateWithTimeout — page.evaluate that won't hang on blocked event loops
+// ---------------------------------------------------------------------------
+
+/**
+ * Run `page.evaluate(...)` but reject after `timeoutMs` if the page event
+ * loop is blocked (heavy SSR hydration, busy service worker, etc.).
+ *
+ * On timeout, logs a warning and resolves with `undefined` so recordings
+ * keep going instead of hitting the full Playwright test timeout.
+ */
+async function evaluateWithTimeout<R>(
+  page: Page,
+  fn: Parameters<Page["evaluate"]>[0],
+  arg?: unknown,
+  timeoutMs = 10_000,
+  label = "page.evaluate",
+): Promise<R | undefined> {
+  let timer: NodeJS.Timeout | undefined;
+  try {
+    return (await Promise.race([
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (page.evaluate as any)(fn, arg),
+      new Promise<undefined>((resolve) => {
+        timer = setTimeout(() => {
+          // eslint-disable-next-line no-console
+          console.warn(
+            `[demowright] ${label} timed out after ${timeoutMs}ms — page event loop likely blocked. Skipping.`,
+          );
+          resolve(undefined);
+        }, timeoutMs);
+      }),
+    ])) as R | undefined;
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+}
+
+// ---------------------------------------------------------------------------
 // hudWait — delay that only runs when HUD is active
 // ---------------------------------------------------------------------------
 
@@ -272,7 +310,8 @@ export async function narrate(
     voice: options?.voice,
   };
 
-  const speechPromise = page.evaluate(
+  const speechPromise = evaluateWithTimeout(
+    page,
     ([t, o]: [string, typeof opts]) => {
       return new Promise<void>((resolve) => {
         const synth = window.speechSynthesis;
@@ -296,6 +335,8 @@ export async function narrate(
       });
     },
     [text, opts] as [string, typeof opts],
+    10_000,
+    "narrate(speechSynthesis)",
   );
 
   if (cb) {
@@ -316,7 +357,8 @@ export async function narrate(
 export async function caption(page: Page, text: string, durationMs = 3000): Promise<void> {
   if (!(await isHudActive(page))) return;
 
-  await page.evaluate(
+  await evaluateWithTimeout(
+    page,
     ([t, d]: [string, number]) => {
       const el = document.createElement("div");
       el.textContent = t;
@@ -357,6 +399,8 @@ export async function caption(page: Page, text: string, durationMs = 3000): Prom
       setTimeout(() => el.remove(), d);
     },
     [text, durationMs] as [string, number],
+    10_000,
+    "caption",
   );
 }
 

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -29,10 +29,13 @@ async function evaluateWithTimeout<A, R>(
   label = "page.evaluate",
 ): Promise<R | undefined> {
   let timer: NodeJS.Timeout | undefined;
-  // Swallow rejections from the abandoned evaluate so it can't surface as
-  // an unhandled promise rejection after we've already raced past it (e.g.
-  // the page closes or navigates while the function is still stuck).
-  const evalPromise = page.evaluate<R, A>(fn, arg).catch(() => undefined);
+  const evalPromise = page.evaluate<R, A>(fn, arg);
+  // Attach a no-op rejection handler to the *original* promise so that, if
+  // we race past it and abandon it, a later rejection (page close, navigate)
+  // can't surface as an unhandled rejection. The original promise itself is
+  // still passed into Promise.race, so legitimate evaluate errors that
+  // happen *before* the timeout are still propagated to the caller.
+  evalPromise.catch(() => {});
   try {
     return await Promise.race<R | undefined>([
       evalPromise,

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -29,9 +29,13 @@ async function evaluateWithTimeout<A, R>(
   label = "page.evaluate",
 ): Promise<R | undefined> {
   let timer: NodeJS.Timeout | undefined;
+  // Swallow rejections from the abandoned evaluate so it can't surface as
+  // an unhandled promise rejection after we've already raced past it (e.g.
+  // the page closes or navigates while the function is still stuck).
+  const evalPromise = page.evaluate<R, A>(fn, arg).catch(() => undefined);
   try {
     return await Promise.race<R | undefined>([
-      page.evaluate<R, A>(fn, arg),
+      evalPromise,
       new Promise<undefined>((resolve) => {
         timer = setTimeout(() => {
           // eslint-disable-next-line no-console

--- a/src/hud-registry.ts
+++ b/src/hud-registry.ts
@@ -43,8 +43,17 @@ export function registerHudPage(page: Page, config?: HudPageConfig): void {
  */
 export async function isHudActive(page: Page): Promise<boolean> {
   if (hudPages.has(page)) return true;
+  // Race the browser-side probe against a short Node-side timer so a blocked
+  // page event loop (heavy SSR hydration, busy service worker, etc.) can't
+  // hang every helper that calls isHudActive.
+  let timer: NodeJS.Timeout | undefined;
   try {
-    const active = await page.evaluate(() => !!(window as any).__qaHud);
+    const active = await Promise.race<boolean>([
+      page.evaluate(() => !!(window as any).__qaHud).catch(() => false),
+      new Promise<boolean>((resolve) => {
+        timer = setTimeout(() => resolve(false), 5_000);
+      }),
+    ]);
     if (active) {
       // Cache with global TTS provider (may have been set by another module instance)
       hudPages.set(page, { tts: g.__qaHudGlobal.tts || false });
@@ -52,6 +61,8 @@ export async function isHudActive(page: Page): Promise<boolean> {
     return active;
   } catch {
     return false;
+  } finally {
+    if (timer) clearTimeout(timer);
   }
 }
 


### PR DESCRIPTION
Closes #3

## Summary
- Adds a Node-side `evaluateWithTimeout` wrapper that races `page.evaluate` against a 10s timer.
- Uses it in `caption()` and the `narrate()` speechSynthesis fallback — the two spots where a blocked browser event loop (SSR hydration, busy service workers, analytics) could hang for the full test timeout.
- On timeout, logs a warning and resolves `undefined` so the recording keeps going instead of dying after 5+ minutes.

## Test plan
- [x] `npm run build`
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)