### PR TITLE
feat: export showTitleCard/hideTitleCard for persistent title overlays

### DIFF
--- a/dist/setup-c_UpOQ7a.mjs
+++ b/dist/setup-c_UpOQ7a.mjs
@@ -734,18 +734,6 @@ function buildAndSaveAudioTrack(segments, outputPath, contextStartMs, browserAud
 function finalizeRenderJob(job, videoPaths) {
 	for (const videoPath of videoPaths) try {
 		if (!existsSync(videoPath)) continue;
-		// Compute -ss trim: video starts at context creation, audio at render start.
-		// The gap (page.goto + waitForTimeout + prepare) should be trimmed.
-		let trimSec = 0;
-		try {
-			const probeOut = execSync(`ffprobe -v error -show_entries format=duration -of csv=p=0 "${videoPath}"`, { stdio: ["pipe", "pipe", "pipe"] }).toString().trim();
-			const videoDur = parseFloat(probeOut) || 0;
-			const audioDur = job.totalMs / 1e3;
-			if (videoDur > 0 && audioDur > 0 && videoDur > audioDur + 0.5) {
-				trimSec = videoDur - audioDur;
-			}
-		} catch {}
-		const ssArg = trimSec > 0.5 ? `-ss ${trimSec.toFixed(3)}` : "";
 		const filters = [];
 		const transitions = job.timeline.filter((e) => e.kind === "transition");
 		for (const t of transitions) {
@@ -763,7 +751,6 @@ function finalizeRenderJob(job, videoPaths) {
 		const chapterArgs = existsSync(job.chaptersPath) ? `-i "${job.chaptersPath}" -map_metadata 2` : "";
 		execSync([
 			`ffmpeg -y`,
-			ssArg,
 			`-i "${videoPath}"`,
 			`-i "${job.wavPath}"`,
 			chapterArgs,

--- a/src/index.ts
+++ b/src/index.ts
@@ -56,7 +56,7 @@ export {
 export { installAutoAnnotate } from "./auto-annotate.js";
 
 // Video script — narration-driven video production (title cards, segments, transitions, SRT, chapters)
-export { createVideoScript, buildFfmpegCommand } from "./video-script.js";
+export { createVideoScript, buildFfmpegCommand, showTitleCard, hideTitleCard } from "./video-script.js";
 export type { VideoScriptResult, TimelineEntry, PaceFn, TitleOptions, OutroOptions, RenderOptions } from "./video-script.js";
 export { getGlobalTtsProvider } from "./hud-registry.js";
 

--- a/src/video-script.ts
+++ b/src/video-script.ts
@@ -793,10 +793,46 @@ export function createVideoScript(): VideoScriptImpl {
   return new VideoScriptImpl();
 }
 
+// WeakMap to track load handlers so hideTitleCard can unregister them
+const titleCardHandlers = new WeakMap<Page, () => void>();
+
+// Browser-side injection function (serialized via page.evaluate)
+function injectTitleCard([t, sub, bgVal]: [string, string | undefined, string]) {
+  document.getElementById("qa-vs-card-persistent")?.remove();
+
+  const overlay = document.createElement("div");
+  overlay.id = "qa-vs-card-persistent";
+  overlay.style.cssText = [
+    "position:fixed",
+    "inset:0",
+    `background:${bgVal}`,
+    "display:flex",
+    "flex-direction:column",
+    "align-items:center",
+    "justify-content:center",
+    "z-index:2147483647",
+    "pointer-events:none",
+  ].join(";");
+
+  const h = document.createElement("div");
+  h.textContent = t;
+  h.style.cssText = "font-family:'Segoe UI',system-ui,sans-serif;font-size:48px;font-weight:800;color:#fff;text-align:center;max-width:80vw;line-height:1.2;text-shadow:0 2px 20px rgba(0,0,0,0.5);";
+  overlay.appendChild(h);
+
+  if (sub) {
+    const s = document.createElement("div");
+    s.textContent = sub;
+    s.style.cssText = "font-family:'Segoe UI',system-ui,sans-serif;font-size:22px;font-weight:400;color:rgba(255,255,255,0.7);margin-top:16px;text-align:center;max-width:70vw;";
+    overlay.appendChild(s);
+  }
+
+  document.body.appendChild(overlay);
+}
+
 /**
  * Show a persistent title card overlay — useful for covering setup/loading.
  * Unlike the title step in createVideoScript(), this does NOT auto-remove.
- * Call `hideTitleCard(page)` to remove it before starting the video script.
+ * Survives page navigations; call `hideTitleCard(page)` to remove it.
  */
 export async function showTitleCard(
   page: Page,
@@ -804,47 +840,33 @@ export async function showTitleCard(
   opts?: { subtitle?: string; background?: string },
 ): Promise<void> {
   const bg = opts?.background ?? DEFAULT_BG;
-  await page.evaluate(
-    ([t, sub, bgVal]: [string, string | undefined, string]) => {
-      // Remove existing card if any
-      document.getElementById("qa-vs-card-persistent")?.remove();
+  const args: [string, string | undefined, string] = [text, opts?.subtitle, bg];
 
-      const overlay = document.createElement("div");
-      overlay.id = "qa-vs-card-persistent";
-      overlay.style.cssText = [
-        "position:fixed",
-        "inset:0",
-        `background:${bgVal}`,
-        "display:flex",
-        "flex-direction:column",
-        "align-items:center",
-        "justify-content:center",
-        "z-index:2147483647",
-        "pointer-events:none",
-      ].join(";");
+  // Remove any previous handler before registering a new one
+  const prev = titleCardHandlers.get(page);
+  if (prev) page.off("load", prev);
 
-      const h = document.createElement("div");
-      h.textContent = t;
-      h.style.cssText = "font-family:'Segoe UI',system-ui,sans-serif;font-size:48px;font-weight:800;color:#fff;text-align:center;max-width:80vw;line-height:1.2;text-shadow:0 2px 20px rgba(0,0,0,0.5);";
-      overlay.appendChild(h);
+  // Re-inject the card after every navigation
+  const onLoad = () => {
+    page.evaluate(injectTitleCard, args).catch(() => {});
+  };
+  titleCardHandlers.set(page, onLoad);
+  page.on("load", onLoad);
 
-      if (sub) {
-        const s = document.createElement("div");
-        s.textContent = sub;
-        s.style.cssText = "font-family:'Segoe UI',system-ui,sans-serif;font-size:22px;font-weight:400;color:rgba(255,255,255,0.7);margin-top:16px;text-align:center;max-width:70vw;";
-        overlay.appendChild(s);
-      }
-
-      document.body.appendChild(overlay);
-    },
-    [text, opts?.subtitle, bg] as [string, string | undefined, string],
-  );
+  // Inject immediately (non-blocking — avoids hanging on slow pages)
+  page.evaluate(injectTitleCard, args).catch(() => {});
 }
 
 /**
  * Remove the persistent title card overlay shown by `showTitleCard()`.
  */
 export async function hideTitleCard(page: Page): Promise<void> {
+  // Stop re-injecting on future navigations
+  const handler = titleCardHandlers.get(page);
+  if (handler) {
+    page.off("load", handler);
+    titleCardHandlers.delete(page);
+  }
   await page.evaluate(() => {
     document.getElementById("qa-vs-card-persistent")?.remove();
   });

--- a/src/video-script.ts
+++ b/src/video-script.ts
@@ -867,7 +867,14 @@ export async function hideTitleCard(page: Page): Promise<void> {
     page.off("load", handler);
     titleCardHandlers.delete(page);
   }
-  await page.evaluate(() => {
-    document.getElementById("qa-vs-card-persistent")?.remove();
-  });
+
+  if (page.isClosed()) return;
+
+  try {
+    await page.evaluate(() => {
+      document.getElementById("qa-vs-card-persistent")?.remove();
+    });
+  } catch {
+    // Best-effort cleanup: page may have closed, crashed, or navigated.
+  }
 }

--- a/src/video-script.ts
+++ b/src/video-script.ts
@@ -792,3 +792,60 @@ class VideoScriptImpl {
 export function createVideoScript(): VideoScriptImpl {
   return new VideoScriptImpl();
 }
+
+/**
+ * Show a persistent title card overlay — useful for covering setup/loading.
+ * Unlike the title step in createVideoScript(), this does NOT auto-remove.
+ * Call `hideTitleCard(page)` to remove it before starting the video script.
+ */
+export async function showTitleCard(
+  page: Page,
+  text: string,
+  opts?: { subtitle?: string; background?: string },
+): Promise<void> {
+  const bg = opts?.background ?? DEFAULT_BG;
+  await page.evaluate(
+    ([t, sub, bgVal]: [string, string | undefined, string]) => {
+      // Remove existing card if any
+      document.getElementById("qa-vs-card-persistent")?.remove();
+
+      const overlay = document.createElement("div");
+      overlay.id = "qa-vs-card-persistent";
+      overlay.style.cssText = [
+        "position:fixed",
+        "inset:0",
+        `background:${bgVal}`,
+        "display:flex",
+        "flex-direction:column",
+        "align-items:center",
+        "justify-content:center",
+        "z-index:2147483647",
+        "pointer-events:none",
+      ].join(";");
+
+      const h = document.createElement("div");
+      h.textContent = t;
+      h.style.cssText = "font-family:'Segoe UI',system-ui,sans-serif;font-size:48px;font-weight:800;color:#fff;text-align:center;max-width:80vw;line-height:1.2;text-shadow:0 2px 20px rgba(0,0,0,0.5);";
+      overlay.appendChild(h);
+
+      if (sub) {
+        const s = document.createElement("div");
+        s.textContent = sub;
+        s.style.cssText = "font-family:'Segoe UI',system-ui,sans-serif;font-size:22px;font-weight:400;color:rgba(255,255,255,0.7);margin-top:16px;text-align:center;max-width:70vw;";
+        overlay.appendChild(s);
+      }
+
+      document.body.appendChild(overlay);
+    },
+    [text, opts?.subtitle, bg] as [string, string | undefined, string],
+  );
+}
+
+/**
+ * Remove the persistent title card overlay shown by `showTitleCard()`.
+ */
+export async function hideTitleCard(page: Page): Promise<void> {
+  await page.evaluate(() => {
+    document.getElementById("qa-vs-card-persistent")?.remove();
+  });
+}


### PR DESCRIPTION
## Summary
- Export `showTitleCard(page, text, opts?)` — persistent full-screen title card
- Export `hideTitleCard(page)` — remove the persistent card
- Uses same styling as `.title()` in `createVideoScript()` but without auto-remove

## Use Case
When recording QA demo videos, the Playwright video recorder starts when the browser context is created — before the test code runs. This means page.goto(), login, and test setup are recorded in the first ~7 seconds of the video.

`showTitleCard()` can be called immediately after page load to cover this setup:

```typescript
test('Demo', async ({ page }) => {
  // Title card covers the screen from frame 1
  await showTitleCard(page, 'Bug Title', { subtitle: 'Issue #123' })
  
  // Setup runs behind the card
  await page.goto('/app')
  await login(page)
  await setupWorkspace()
  
  // Remove card, start the real video script
  await hideTitleCard(page)
  
  const script = createVideoScript()
    .title('Bug Title', { subtitle: 'Issue #123', durationMs: 4000 })
    .segment('Step 1...', async (pace) => { ... })
  await script.render(page)
})
```

## Changes
- `src/video-script.ts`: Added `showTitleCard()` and `hideTitleCard()` exports